### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -16,20 +16,20 @@ MINIEC	KEYWORD1
 calibratepH7	KEYWORD2
 calibratepH4	KEYWORD2
 calibratepH10	KEYWORD2
-calcpHSlope		KEYWORD2
-calcpH  		KEYWORD2
+calcpHSlope	KEYWORD2
+calcpH	KEYWORD2
 tempAdjustpH	KEYWORD2
-updateopAmpGain KEYWORD2
+updateopAmpGain	KEYWORD2
 writeParamsToEEPROM	KEYWORD2
 reset_pHParams	KEYWORD2
 calibrateeCLow	KEYWORD2
 calibrateeCHigh	KEYWORD2
-calceCSlope		KEYWORD2
-calceC 			KEYWORD2
+calceCSlope	KEYWORD2
+calceC	KEYWORD2
 tempAdjusteC	KEYWORD2
-updateRGain		KEYWORD2
+updateRGainKEYWORD2
 updateoscVout	KEYWORD2
-updatekCell		KEYWORD2
+updatekCell	KEYWORD2
 reset_eCParams	KEYWORD2
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords